### PR TITLE
use reinterpret_cast uint8_t[] to uint16_t/uint32_t

### DIFF
--- a/FRAM_MB85RC_I2C.cpp
+++ b/FRAM_MB85RC_I2C.cpp
@@ -407,7 +407,7 @@ byte FRAM_MB85RC_I2C::readWord(uint16_t framAddr, uint16_t *value)
 {
 	uint8_t buffer[2];
 	byte result = FRAM_MB85RC_I2C::readArray(framAddr, 2, buffer);
-	*value = ((uint16_t) buffer[0] << 8) + (uint16_t)buffer[1];
+	*value = *reinterpret_cast<uint16_t *>(buffer);
 	return result;
 }
 
@@ -425,7 +425,7 @@ byte FRAM_MB85RC_I2C::readWord(uint16_t framAddr, uint16_t *value)
 /**************************************************************************/
 byte FRAM_MB85RC_I2C::writeWord(uint16_t framAddr, uint16_t value)
 {
-	uint8_t buffer[2] = {(value >> 8), (value & 0xFF)};
+	uint8_t *buffer = reinterpret_cast<uint8_t *>(&value);
 	return FRAM_MB85RC_I2C::writeArray(framAddr, 2, buffer);
 }
 /**************************************************************************/
@@ -444,7 +444,7 @@ byte FRAM_MB85RC_I2C::readLong(uint16_t framAddr, uint32_t *value)
 {
 	uint8_t buffer[4];
 	byte result = FRAM_MB85RC_I2C::readArray(framAddr, 4, buffer);
-	*value = ((uint32_t) buffer[0] << 24) + ((uint32_t)buffer[1] << 16) + ((uint32_t)buffer[2] << 8) + (uint32_t)buffer[3];
+	*value = *reinterpret_cast<uint32_t *>(buffer);
 	return result;
 
 }
@@ -462,11 +462,7 @@ byte FRAM_MB85RC_I2C::readLong(uint16_t framAddr, uint32_t *value)
 /**************************************************************************/
 byte FRAM_MB85RC_I2C::writeLong(uint16_t framAddr, uint32_t value)
 {
-	uint8_t buffer[4];
-	buffer[0] = (uint8_t)(value >> 24);
-	buffer[1] = (uint8_t)((value & 0xFFFFFF) >> 16);
-	buffer[2] = (uint8_t)((value & 0xFFFF) >> 8);
-	buffer[3] = (uint8_t)(value & 0xFF);
+	uint8_t *buffer = reinterpret_cast<uint8_t *>(&value);
 	return FRAM_MB85RC_I2C::writeArray(framAddr, 4, buffer);
 }
 /**************************************************************************/


### PR DESCRIPTION
instead of shifting and or-ing the bits.
this should gives better performance and less opcodes required.

breaks previous saved data, since avr is big-endian system, low bytes
are stored first.