### PR TITLE
Fixes default value for serial debug

### DIFF
--- a/FRAM_MB85RC_I2C.h
+++ b/FRAM_MB85RC_I2C.h
@@ -61,7 +61,7 @@
 
 // Enabling debug I2C - comment to disable / normal operations
 #ifndef SERIAL_DEBUG
-#define SERIAL_DEBUG 1
+#define SERIAL_DEBUG 0
 #endif
 
 // IDs


### PR DESCRIPTION
Currently, the default value for SERIAL_DEBUG is 1 which prints a lot for statements in the serial monitor unnecessarily.
Updated the default value to be 0 / false.